### PR TITLE
update known issues to include workaround for compute node ip address

### DIFF
--- a/examples/cluster-configs/trn1-16-nodes-pcluster.md
+++ b/examples/cluster-configs/trn1-16-nodes-pcluster.md
@@ -1,67 +1,7 @@
 # Create ParallelCluster
 
-1. Once your VPC, ParallelCluster python package, and key pair are set up, you are ready to create a ParallelCluster. Copy the following content into a launch.yaml file in your local desktop where AWS ParallelCluster CLI is installed. Here is the YAML if your operating system (OS) choice is Amazon Linux 2:
+1. Once your VPC, ParallelCluster python package, and key pair are set up, you are ready to create a ParallelCluster. Copy the following content into a launch.yaml file in your local desktop where AWS ParallelCluster CLI is installed. In an example here, the head node is designated to run on Ubuntu 20.04. Here is the example YAML file:  
 
-```
-Region: <YOUR REGION> # i.e., us-west-2
-Image:
-  Os: alinux2
-HeadNode:
-  InstanceType: c5.4xlarge
-  Networking:
-    SubnetId: subnet-<PUBLIC SUBNET ID>
-  Ssh:
-    KeyName: <KEY NAME WITHOUT .PEM>
-  LocalStorage:
-    RootVolume:
-      Size: 1024
-  CustomActions:
-    OnNodeConfigured:
-      Script: s3://neuron-s3/pcluster/post-install-scripts/neuron-installation/v2.4.0/al2/pt/install_neuron.sh
-  Iam:
-    S3Access:
-       - BucketName: neuron-s3
-         EnableWriteAccess: false
-Scheduling:
-  Scheduler: slurm
-  SlurmQueues:
-    - Name: compute1
-      CapacityType: ONDEMAND
-      ComputeSettings:
-        LocalStorage:
-          RootVolume:
-            Size: 1024
-          EphemeralVolume:
-            MountDir: /local_storage
-      ComputeResources:
-        - Efa:
-            Enabled: true
-          InstanceType: trn1.32xlarge
-          MaxCount: 16
-          MinCount: 0
-          Name: queue1-i1
-      Networking:
-        SubnetIds:
-          - subnet-<PRIVATE SUBNET ID>
-        PlacementGroup:
-          Enabled: true
-      CustomActions:
-        OnNodeConfigured:
-          Script: s3://neuron-s3/pcluster/post-install-scripts/neuron-installation/v2.4.0/al2/pt/install_neuron.sh
-      Iam:
-        S3Access:
-          - BucketName: neuron-s3
-            EnableWriteAccess: false
-SharedStorage:
-- EfsSettings:
-    ProvisionedThroughput: 1024
-    ThroughputMode: provisioned
-  MountDir: /efs
-  Name: neuron
-  StorageType: Efs
-  ```
-
-If your OS choice is Ubuntu 20.04, here is an example YAML:
 
 ```
 Region: <YOUR REGION> # i.e., us-west-2

--- a/examples/cluster-configs/trn1-16-nodes-pcluster.md
+++ b/examples/cluster-configs/trn1-16-nodes-pcluster.md
@@ -1,6 +1,67 @@
 # Create ParallelCluster
 
-1. Once your VPC, ParallelCluster python package, and key pair are set up, you are ready to create a ParallelCluster. Copy the following content into a launch.yaml file in your local desktop where AWS ParallelCluster CLI is installed. In an example here, the head node is designated to run on Ubuntu 20.04. Here is the example YAML file:  
+1. Once your VPC, ParallelCluster python package, and key pair are set up, you are ready to create a ParallelCluster. Copy the following content into a launch.yaml file in your local desktop where AWS ParallelCluster CLI is installed. Here is the YAML if your operating system (OS) choice is Amazon Linux 2:
+
+```
+Region: <YOUR REGION> # i.e., us-west-2
+Image:
+  Os: alinux2
+HeadNode:
+  InstanceType: c5.4xlarge
+  Networking:
+    SubnetId: subnet-<PUBLIC SUBNET ID>
+  Ssh:
+    KeyName: <KEY NAME WITHOUT .PEM>
+  LocalStorage:
+    RootVolume:
+      Size: 1024
+  CustomActions:
+    OnNodeConfigured:
+      Script: s3://neuron-s3/pcluster/post-install-scripts/neuron-installation/v2.4.0/al2/pt/install_neuron.sh
+  Iam:
+    S3Access:
+       - BucketName: neuron-s3
+         EnableWriteAccess: false
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+    - Name: compute1
+      CapacityType: ONDEMAND
+      ComputeSettings:
+        LocalStorage:
+          RootVolume:
+            Size: 1024
+          EphemeralVolume:
+            MountDir: /local_storage
+      ComputeResources:
+        - Efa:
+            Enabled: true
+          InstanceType: trn1.32xlarge
+          MaxCount: 16
+          MinCount: 0
+          Name: queue1-i1
+      Networking:
+        SubnetIds:
+          - subnet-<PRIVATE SUBNET ID>
+        PlacementGroup:
+          Enabled: true
+      CustomActions:
+        OnNodeConfigured:
+          Script: s3://neuron-s3/pcluster/post-install-scripts/neuron-installation/v2.4.0/al2/pt/install_neuron.sh
+      Iam:
+        S3Access:
+          - BucketName: neuron-s3
+            EnableWriteAccess: false
+SharedStorage:
+- EfsSettings:
+    ProvisionedThroughput: 1024
+    ThroughputMode: provisioned
+  MountDir: /efs
+  Name: neuron
+  StorageType: Efs
+```
+
+If your OS choice is Ubuntu 20.04, here is an example YAML:
 
 
 ```

--- a/examples/jobs/dp-bert-launch-job.md
+++ b/examples/jobs/dp-bert-launch-job.md
@@ -66,7 +66,7 @@ Some useful SLURM commands are `sinfo`,  `squeue` and `scontrol`. `sinfo` comman
 
 - The current setup supports up to 16 nodes BERT pretraining.
 
-- For dynamic cluster with `MinCount = 0`, /etc/hosts IP addresses of compute nodes may not match with what's in `nslookup` upon cluster relaunch. A temporary workaround is to add the following code snippet on top of `run_dp_bert_large_hf_pretrain_bf16_s128.sh`:
+- For dynamic cluster with `MinCount = 0`, /etc/hosts IP addresses of compute nodes may not match with what's in `nslookup` upon cluster relaunch. Therefore, for your information, a temporary workaround is included on top of custom installation script:
 
 ```
 IP="$(host $HOSTNAME| awk '{print $4}')"

--- a/examples/jobs/dp-bert-launch-job.md
+++ b/examples/jobs/dp-bert-launch-job.md
@@ -66,7 +66,7 @@ Some useful SLURM commands are `sinfo`,  `squeue` and `scontrol`. `sinfo` comman
 
 - The current setup supports up to 16 nodes BERT pretraining.
 
-- For dynamic cluster with `MinCount = 0`, /etc/hosts IP addresses of compute nodes may not match with what's in `nslookup` upon cluster relaunch. Therefore, for your information, a temporary workaround is included on top of custom installation script:
+- For dynamic cluster with `MinCount = 0`, /etc/hosts IP addresses of compute nodes may not match with what's in `nslookup` upon cluster relaunch. Therefore, for your information, a temporary workaround is included in `install_neuron.sh` post-install script:
 
 ```
 IP="$(host $HOSTNAME| awk '{print $4}')"

--- a/examples/jobs/dp-bert-launch-job.md
+++ b/examples/jobs/dp-bert-launch-job.md
@@ -66,6 +66,16 @@ Some useful SLURM commands are `sinfo`,  `squeue` and `scontrol`. `sinfo` comman
 
 - The current setup supports up to 16 nodes BERT pretraining.
 
+- For dynamic cluster with `MinCount = 0`, /etc/hosts IP addresses of compute nodes may not match with what's in `nslookup` upon cluster relaunch. A temporary workaround is to add the following code snippet on top of `run_dp_bert_large_hf_pretrain_bf16_s128.sh`:
+
+```
+IP="$(host $HOSTNAME| awk '{print $4}')"
+DOMAIN=$(jq .cluster.dns_domain /etc/chef/dna.json | tr -d \")
+sudo sed -i "/$HOSTNAME/d" /etc/hosts
+sudo bash -c "echo '$IP $HOSTNAME.${DOMAIN::-1} $HOSTNAME' >> /etc/hosts"
+```
+
+
 ## Troubleshooting guide
 
 See [Troubleshooting Guide for AWS ParallelCluster](https://docs.aws.amazon.com/parallelcluster/latest/ug/troubleshooting-v3.html) for more details and fixes to common issues.


### PR DESCRIPTION
Compute nodes IP address mismatched when relaunching a dynamic cluster with MinCount = 0. Temporary fix is introduced in Known issues/limitations section. The code snippet introduced will update etc/hosts/ of the compute node for correct IP address during relaunch.