### PR TITLE
Update trn1-16-nodes-pcluster.md to correct trn1n instance type

### DIFF
--- a/examples/cluster-configs/trn1-16-nodes-pcluster.md
+++ b/examples/cluster-configs/trn1-16-nodes-pcluster.md
@@ -36,7 +36,7 @@ Scheduling:
       ComputeResources:
         - Efa:
             Enabled: true
-          InstanceType: trn1.32xlarge
+          InstanceType: trn1n.32xlarge
           MaxCount: 16
           MinCount: 0
           Name: queue1-i1


### PR DESCRIPTION
Currently trn1 instance type doesn't support EFA so need to use trn1n