### PR TITLE
Adding comment to ignore loss=nan value

### DIFF
--- a/examples/jobs/neuronx-nemo-megatron-gpt-job.md
+++ b/examples/jobs/neuronx-nemo-megatron-gpt-job.md
@@ -168,6 +168,8 @@ Epoch 0:   0%|          | 190/301501 [59:30<1572:41:13, 18.79s/it, loss=7.74, v_
 Epoch 0:   0%|          | 191/301501 [59:48<1572:21:28, 18.79s/it, loss=7.73, v_num=3-16, reduced_train_loss=7.910, global_step=190.0, consumed_samples=24320.0]
 ```
 
+The `reduced_train_loss` output here will be your true loss value. Please ignore the `loss=` value.
+
 ## Monitor training
 ### TensorBoard
 In addition to the text-based job monitoring described in the previous section, you can also use standard tools such as TensorBoard to monitor training job progress. To view an ongoing training job in TensorBoard, you first need to identify the experiment directory associated with your ongoing job. This will typically be the most recently created directory under `~/neuronx-nemo-megatron/nemo/examples/nlp/language_modeling/nemo_experiments/megatron_gpt`. Once you have identifed the directory, `cd` into it, and then launch TensorBoard:

--- a/examples/jobs/neuronx-nemo-megatron-llamav2-job.md
+++ b/examples/jobs/neuronx-nemo-megatron-llamav2-job.md
@@ -231,6 +231,8 @@ Epoch 0:  22%|██▏       | 4500/20101 [22:26:32<77:48:18, 17.95s/it, loss=2
 Epoch 0:  22%|██▏       | 4500/20101 [22:26:32<77:48:18, 17.95s/it, loss=2.44, v_num=5563, reduced_train_loss=2.450, gradient_norm=0.120, parameter_norm=1864.0, global_step=4512.0, consumed_samples=1.16e+6, iteration_time=16.50]
 ```
 
+The `reduced_train_loss` output here will be your true loss value. Please ignore the `loss=` value.
+
 ## Monitor training
 ### TensorBoard
 In addition to the text-based job monitoring described in the previous section, you can also use standard tools such as TensorBoard to monitor training job progress. To view an ongoing training job in TensorBoard, you first need to identify the experiment directory associated with your ongoing job. This will typically be the most recently created directory under `~/neuronx-nemo-megatron/nemo/examples/nlp/language_modeling/nemo_experiments/megatron_llama`. Once you have identifed the directory, `cd` into it, and then launch TensorBoard:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Loss= is a garbage value, ensure customers only look at the reduced_train_loss value


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
